### PR TITLE
Force the 'text/html' header

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -299,7 +299,7 @@ angular.module('mm.foundation.modal', ['mm.foundation.transition'])
 
           function getTemplatePromise(options) {
             return options.template ? $q.when(options.template) :
-              $http.get(options.templateUrl, {cache: $templateCache}).then(function (result) {
+              $http.get(options.templateUrl, {cache: $templateCache, headers: { Accept: 'text/html' }}).then(function (result) {
                 return result.data;
               });
           }


### PR DESCRIPTION
It uses application/json by default which break the application behaviour.
